### PR TITLE
Removing Start and End Date from Key Creation

### DIFF
--- a/securedpreferencestore/src/main/java/devliving/online/securedpreferencestore/EncryptionManager.java
+++ b/securedpreferencestore/src/main/java/devliving/online/securedpreferencestore/EncryptionManager.java
@@ -480,10 +480,6 @@ public class EncryptionManager {
 
     @TargetApi(Build.VERSION_CODES.M)
     boolean generateAESKey() throws KeyStoreException, NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException {
-        Calendar start = Calendar.getInstance();
-        Calendar end = Calendar.getInstance();
-        end.add(Calendar.YEAR, 25);
-
         if (!mStore.containsAlias(AES_KEY_ALIAS)) {
             KeyGenerator keyGen = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, KEYSTORE_PROVIDER);
 
@@ -491,8 +487,6 @@ public class EncryptionManager {
                     .setCertificateSubject(new X500Principal("CN = Secured Preference Store, O = Devliving Online"))
                     .setCertificateSerialNumber(BigInteger.ONE)
                     .setKeySize(AES_BIT_LENGTH)
-                    .setKeyValidityStart(start.getTime())
-                    .setKeyValidityEnd(end.getTime())
                     .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
                     .setRandomizedEncryptionRequired(false) //TODO: set to true and let the Cipher generate a secured IV

--- a/securedpreferencestore/src/main/java/devliving/online/securedpreferencestore/EncryptionManager.java
+++ b/securedpreferencestore/src/main/java/devliving/online/securedpreferencestore/EncryptionManager.java
@@ -30,7 +30,6 @@ import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.List;
 
 import javax.crypto.BadPaddingException;
@@ -577,11 +576,7 @@ public class EncryptionManager {
     @SuppressWarnings("WrongConstant")
     void generateRSAKeys(Context context) throws NoSuchProviderException, NoSuchAlgorithmException, InvalidAlgorithmParameterException, KeyStoreException {
         if (!mStore.containsAlias(RSA_KEY_ALIAS)) {
-            Calendar start = Calendar.getInstance();
-            Calendar end = Calendar.getInstance();
-            end.add(Calendar.YEAR, 25);
-
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEY_ALGORITHM_RSA, KEYSTORE_PROVIDER);
+                        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(KEY_ALGORITHM_RSA, KEYSTORE_PROVIDER);
 
             KeyPairGeneratorSpec spec;
 
@@ -590,16 +585,12 @@ public class EncryptionManager {
                         .setAlias(RSA_KEY_ALIAS)
                         .setKeySize(RSA_BIT_LENGTH)
                         .setKeyType(KEY_ALGORITHM_RSA)
-                        .setStartDate(start.getTime())
-                        .setEndDate(end.getTime())
                         .setSerialNumber(BigInteger.ONE)
                         .setSubject(new X500Principal("CN = Secured Preference Store, O = Devliving Online"))
                         .build();
             } else {
                 spec = new KeyPairGeneratorSpec.Builder(context)
                         .setAlias(RSA_KEY_ALIAS)
-                        .setStartDate(start.getTime())
-                        .setEndDate(end.getTime())
                         .setSerialNumber(BigInteger.ONE)
                         .setSubject(new X500Principal("CN = Secured Preference Store, O = Devliving Online"))
                         .build();


### PR DESCRIPTION
There is no longer a validity period set on key creation. Perhaps if this is needed in the future then they could be options that are passed in to the builder.