### PR TITLE
Remove: The explicit allowBackup value from the manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="devliving.online.securedpreferencestoresample">
 
     <application
-        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"


### PR DESCRIPTION
Removing the explicit allowBackup from the library will implicitly keep the same functionality and will also allow for easier control in the library user's top level manifest (otherwise I have to do a tools:replace="android:allowBackup" in my manifest).