### PR TITLE
[FIXED] KeyStore exception android.os.ServiceSpecificException:  (code 7)

### DIFF
--- a/securedpreferencestore/src/main/java/devliving/online/securedpreferencestore/EncryptionManager.java
+++ b/securedpreferencestore/src/main/java/devliving/online/securedpreferencestore/EncryptionManager.java
@@ -688,8 +688,7 @@ public class EncryptionManager {
     void loadKey(SharedPreferences prefStore) throws KeyStoreException, UnrecoverableEntryException, NoSuchAlgorithmException, NoSuchPaddingException, NoSuchProviderException, InvalidKeyException, IOException {
         if (!isCompatMode) {
             if (mStore.containsAlias(AES_KEY_ALIAS) && mStore.entryInstanceOf(AES_KEY_ALIAS, KeyStore.SecretKeyEntry.class)) {
-                KeyStore.SecretKeyEntry entry = (KeyStore.SecretKeyEntry) mStore.getEntry(AES_KEY_ALIAS, null);
-                aesKey = entry.getSecretKey();
+                aesKey = (SecretKey) mStore.getKey(AES_KEY_ALIAS, null);
             }
         } else {
             aesKey = getFallbackAESKey(prefStore);


### PR DESCRIPTION
Fixed secure preferences initialization with Android KeyStore, as described in https://stackoverflow.com/questions/52024752/android-p-keystore-exception-android-os-servicespecificexception?rq=1