### PR TITLE
Prevent the Application field Label from interfering with other module Manifest Files.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 

--- a/securedpreferencestore/src/main/AndroidManifest.xml
+++ b/securedpreferencestore/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
     package="devliving.online.securedpreferencestore">
 
-    <application
-        android:label="@string/app_name">
-
-    </application>
+    <application />
 
 </manifest>

--- a/securedpreferencestore/src/main/res/values/strings.xml
+++ b/securedpreferencestore/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">SecuredPreferenceStore</string>
 </resources>


### PR DESCRIPTION
Integrating this library into another library will cause a manifest issue due to the `android:label` attribute  on the `application` tag.